### PR TITLE
Feature: save-name for single report

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ This method will create an aggregated EARL report from all urls.
 
 ### Usage options
 
-| Alias | Command                  | Value                                             | Information                                                           |
-| ----- | ------------------------ | ------------------------------------------------- | --------------------------------------------------------------------- |
-| -u    | --url                    | `<url>`                                           | Url to evaluate                                                       |
-| -f    | --file                   | `<path-to-file>`                                  | File with urls to evaluate                                            |
-| -c    | --crawl                  | `<domain>`                                        | Domain to crawl                                                       |
-| -m    | --module                 | `act wcag bp`                                     | Choose which modules to execute                                       |
-| -r    | --report-type            | `"earl" or "earl-a"`                              | Convert the evaluation to `earl` or `earl-a` (_earl-aggregated_)      |
-| -s    | --save-name              | `<name>`                                          | The name to save the aggregated earl reports (_earl-a_)               |
-| -t    | --timeout                | `<number>`                                        | Timeout for page to load                                              |
-| -w    | --waitUntil              | `load doncontentloaded networkidle0 networkidle2` | Events to wait before starting evaluation                             |
-| -p    | --maxParallelEvaluations | `<number>`                                        | Evaluates multiples urls ate the same time (_experimental_)           |
-| -j    | --json                   | `<file>`                                          | Loads a json file with the configs to execute. Check an example below |
-| -h    | --help                   |                                                   | Print the help menu                                                   |
+| Alias | Command                  | Value                                             | Information                                                                                                                                  |
+|-------|--------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| -u    | --url                    | `<url>`                                           | Url to evaluate                                                                                                                              |
+| -f    | --file                   | `<path-to-file>`                                  | File with urls to evaluate                                                                                                                   |
+| -c    | --crawl                  | `<domain>`                                        | Domain to crawl                                                                                                                              |
+| -m    | --module                 | `act wcag bp`                                     | Choose which modules to execute                                                                                                              |
+| -r    | --report-type            | `"earl" or "earl-a"`                              | Convert the evaluation to `earl` or `earl-a` (_earl-aggregated_)                                                                             |
+| -s    | --save-name              | `<name>`                                          | The name to save the aggregated earl reports (_earl-a_) or a single report to. Cannot be used when generating multiple reports using --urls. |
+| -t    | --timeout                | `<number>`                                        | Timeout for page to load                                                                                                                     |
+| -w    | --waitUntil              | `load doncontentloaded networkidle0 networkidle2` | Events to wait before starting evaluation                                                                                                    |
+| -p    | --maxParallelEvaluations | `<number>`                                        | Evaluates multiples urls ate the same time (_experimental_)                                                                                  |
+| -j    | --json                   | `<file>`                                          | Loads a json file with the configs to execute. Check an example below                                                                        |
+| -h    | --help                   |                                                   | Print the help menu                                                                                                                          |
 
 ### -j, --json config file example
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ async function cli(): Promise<void> {
 
     await handleReporting(reports, options);
   } catch (err) {
-    if (err?.message === 'Invalid input method') {
+    if (err instanceof Error && err.message === 'Invalid input method') {
       printHelp();
     } else {
       console.error(err);
@@ -42,11 +42,19 @@ async function handleReporting(reports: { [url: string]: EvaluationReport }, opt
   delete options.report;
   delete options['save-name'];
 
+  if (!!saveName && Object.keys(reports || {}).length > 1) {
+    throw new Error('Option save-name cannot be used when generating multiple reports');
+  }
+
   if (reportType) {
     if (reportType === 'earl') {
-      const earlReports = generateEARLReport(reports);
-      for (const url in earlReports || {}) {
-        await saveReport(url, earlReports[url]);
+      const earlReports = generateEARLReport(reports) || {};
+      for (const url in earlReports) {
+        if (undefined !== saveName) {
+          await saveReport(saveName, earlReports[url], true);
+        } else {
+          await saveReport(url, earlReports[url]);
+        }
       }
     } else if (reportType === 'earl-a') {
       const earlOptions = checkEarlOptions(options, saveName);
@@ -59,7 +67,11 @@ async function handleReporting(reports: { [url: string]: EvaluationReport }, opt
   } else {
     for (const url in reports ?? {}) {
       const report = <EvaluationReport>reports[url];
-      await saveReport(url, report);
+      if (undefined !== saveName) {
+        await saveReport(saveName, report, true);
+      } else {
+        await saveReport(url, report);
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,14 +48,7 @@ async function handleReporting(reports: { [url: string]: EvaluationReport }, opt
 
   if (reportType) {
     if (reportType === 'earl') {
-      const earlReports = generateEARLReport(reports) || {};
-      for (const url in earlReports) {
-        if (undefined !== saveName) {
-          await saveReport(saveName, earlReports[url], true);
-        } else {
-          await saveReport(url, earlReports[url]);
-        }
-      }
+      await saveEarlReports(reports, saveName);
     } else if (reportType === 'earl-a') {
       const earlOptions = checkEarlOptions(options, saveName);
       const earlReport = generateEARLReport(reports, earlOptions);
@@ -65,13 +58,28 @@ async function handleReporting(reports: { [url: string]: EvaluationReport }, opt
       throw new Error('Invalid reporter format');
     }
   } else {
-    for (const url in reports ?? {}) {
-      const report = <EvaluationReport>reports[url];
-      if (undefined !== saveName) {
-        await saveReport(saveName, report, true);
-      } else {
-        await saveReport(url, report);
-      }
+    await saveReports(reports, saveName);
+  }
+}
+
+async function saveEarlReports(reports: { [url: string]: EvaluationReport }, saveName?: string): Promise<void> {
+  const earlReports = generateEARLReport(reports) || {};
+  for (const url in earlReports) {
+    if (saveName) {
+      await saveReport(saveName, earlReports[url], true);
+    } else {
+      await saveReport(url, earlReports[url]);
+    }
+  }
+}
+
+async function saveReports(reports: { [url: string]: EvaluationReport }, saveName?: string): Promise<void> {
+  for (const url in reports ?? {}) {
+    const report = <EvaluationReport>reports[url];
+    if (saveName) {
+      await saveReport(saveName, report, true);
+    } else {
+      await saveReport(url, report);
     }
   }
 }

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -214,7 +214,8 @@ const options = [
     alias: 's',
     type: String,
     typeLabel: '{underline name}',
-    description: 'The name to save the aggregated earl reports (earl-a).'
+    description:
+      'The name to save the aggregated earl reports (earl-a) or a single report to. Cannot be used when generating multiple reports using --urls.'
   },
   {
     name: 'timeout',

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -43,8 +43,8 @@ function parseModules(mainOptions: CommandLineOptions, options: QualwebOptions):
           case 'bp':
             options.execute.bp = true;
             break;
- //         case 'wappalyzer':
- //           options.execute.wappalyzer = true;
+            //         case 'wappalyzer':
+            //           options.execute.wappalyzer = true;
             break;
           case 'counter':
             options.execute.counter = true;


### PR DESCRIPTION
Currently, the `--save-name` option only has effect when generating aggregated reports (`--report-type earl-a`).

Specifying the output file name will be handy for other reports as well, e.g. when running automated tests on a website, and this pull request suggests an implementation handling a custom output file name when generating a _single_ report. [Another pull request](https://github.com/qualweb/cli/pull/16) (https://github.com/qualweb/cli/pull/16) suggests handling of multiple reports.

Addresses the issue mentioned in https://github.com/qualweb/cli/issues/11.

**Note**: Contains changes from https://github.com/qualweb/cli/pull/14.


