### PR TITLE
Feature: save-name for multiple reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,39 @@ This method will create an aggregated EARL report from all urls.
 
 ### Usage options
 
-| Alias | Command                  | Value                                             | Information                                                           |
-| ----- | ------------------------ | ------------------------------------------------- | --------------------------------------------------------------------- |
-| -u    | --url                    | `<url>`                                           | Url to evaluate                                                       |
-| -f    | --file                   | `<path-to-file>`                                  | File with urls to evaluate                                            |
-| -c    | --crawl                  | `<domain>`                                        | Domain to crawl                                                       |
-| -m    | --module                 | `act wcag bp`                                     | Choose which modules to execute                                       |
-| -r    | --report-type            | `"earl" or "earl-a"`                              | Convert the evaluation to `earl` or `earl-a` (_earl-aggregated_)      |
-| -s    | --save-name              | `<name>`                                          | The name to save the aggregated earl reports (_earl-a_)               |
-| -t    | --timeout                | `<number>`                                        | Timeout for page to load                                              |
-| -w    | --waitUntil              | `load doncontentloaded networkidle0 networkidle2` | Events to wait before starting evaluation                             |
-| -p    | --maxParallelEvaluations | `<number>`                                        | Evaluates multiples urls ate the same time (_experimental_)           |
-| -j    | --json                   | `<file>`                                          | Loads a json file with the configs to execute. Check an example below |
-| -h    | --help                   |                                                   | Print the help menu                                                   |
+| Alias | Command                  | Value                                             | Information                                                                                                                |
+|-------|--------------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| -u    | --url                    | `<url>`                                           | Url to evaluate                                                                                                            |
+| -f    | --file                   | `<path-to-file>`                                  | File with urls to evaluate                                                                                                 |
+| -c    | --crawl                  | `<domain>`                                        | Domain to crawl                                                                                                            |
+| -m    | --module                 | `act wcag bp`                                     | Choose which modules to execute                                                                                            |
+| -r    | --report-type            | `"earl" or "earl-a"`                              | Convert the evaluation to `earl` or `earl-a` (_earl-aggregated_)                                                           |
+| -s    | --save-name              | `<name>`                                          | The name to save the aggregated earl reports (_earl-a_) or multiple reports to. See [Save names](#save-names) for details. |
+| -t    | --timeout                | `<number>`                                        | Timeout for page to load                                                                                                   |
+| -w    | --waitUntil              | `load doncontentloaded networkidle0 networkidle2` | Events to wait before starting evaluation                                                                                  |
+| -p    | --maxParallelEvaluations | `<number>`                                        | Evaluates multiples urls ate the same time (_experimental_)                                                                |
+| -j    | --json                   | `<file>`                                          | Loads a json file with the configs to execute. Check an example below                                                      |
+| -h    | --help                   |                                                   | Print the help menu                                                                                                        |
+
+#### Save names
+
+When saving (multiple) reports, placeholders in the `save-name` option can be used to generate file names:
+
+| Placeholder | Value                         | Information                                                 |
+|-------------|-------------------------------|-------------------------------------------------------------|
+| %url%       | The source url for the report |                                                             |
+| %time%      | The timestamp                 |                                                             |
+| %index%     | The index of the report       | Padded with leading zeroes to a length of three, e.g. `087` |
+
+##### Examples
+
+* Simulate the default behaviour (i.e. when `--save-name` is not specified): `--save-name %url%_%time%.json`
+* Number the reports and save in the `reports/` folder: `--save-name reports/report_%index%.json`
+
+##### Notes
+
+* If `save-name` does not contain placeholders, all reports will be saved to the same file name, i.e. only the last one will actually be saved.
+* When saving to a folder, the folder must be created prior to running `qw`.
 
 ### -j, --json config file example
 

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -214,7 +214,8 @@ const options = [
     alias: 's',
     type: String,
     typeLabel: '{underline name}',
-    description: 'The name to save the aggregated earl reports (earl-a).'
+    description:
+      'The name to save the aggregated earl reports (earl-a) or multiple reports to. Can contain the placeholders %url%, %time% and %index% (padded with leading zeroes to a length of three, e.g. 087).'
   },
   {
     name: 'timeout',

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -43,8 +43,8 @@ function parseModules(mainOptions: CommandLineOptions, options: QualwebOptions):
           case 'bp':
             options.execute.bp = true;
             break;
- //         case 'wappalyzer':
- //           options.execute.wappalyzer = true;
+            //         case 'wappalyzer':
+            //           options.execute.wappalyzer = true;
             break;
           case 'counter':
             options.execute.counter = true;


### PR DESCRIPTION
Currently, the `--save-name` option only has effect when generating aggregated reports (`--report-type earl-a`).

Specifying the output file name will be handy for other reports as well, e.g. when running automated tests on a website, and this pull request suggests an implementation handling a custom output file name in general. Another pull request (https://github.com/qualweb/cli/pull/15) suggests handling of just a single report.

Addresses the issue mentioned in https://github.com/qualweb/cli/issues/11.

